### PR TITLE
fix/liveseo-heading-structure

### DIFF
--- a/components/footer/Newsletter.tsx
+++ b/components/footer/Newsletter.tsx
@@ -52,9 +52,9 @@ function Newsletter(
     >
       <div class="flex flex-col gap-4">
         {content?.title && (
-          <h4 class={tiled ? "text-2xl lg:text-3xl" : "text-lg"}>
+          <strong class={tiled ? "text-2xl lg:text-3xl" : "text-lg"}>
             {content?.title}
-          </h4>
+          </strong>
         )}
         {content?.description && <div>{content?.description}</div>}
       </div>

--- a/components/footer/PaymentMethods.tsx
+++ b/components/footer/PaymentMethods.tsx
@@ -11,7 +11,7 @@ export default function PaymentMethods(
     <>
       {content && content.items && content.items.length > 0 && (
         <div class="flex flex-col gap-4">
-          {content.title && <h3 class="text-lg">{content.title}</h3>}
+          {content.title && <span class="text-lg">{content.title}</span>}
           <ul class="flex items-center gap-4 flex-wrap">
             {content.items.map((item) => {
               return (

--- a/components/footer/Social.tsx
+++ b/components/footer/Social.tsx
@@ -21,7 +21,7 @@ export default function Social(
     <>
       {content && content.items && content.items.length > 0 && (
         <div class="flex flex-col gap-4">
-          {content.title && <h3 class="text-lg">{content.title}</h3>}
+          {content.title && <span class="text-lg">{content.title}</span>}
           <ul
             class={`flex gap-4 ${
               vertical ? "lg:flex-col lg:items-start" : "flex-wrap items-center"

--- a/components/header/Drawers.tsx
+++ b/components/header/Drawers.tsx
@@ -31,9 +31,9 @@ const Aside = (
 ) => (
   <div class="bg-base-100 grid grid-rows-[auto_1fr] h-full divide-y max-w-[100vw]">
     <div class="flex justify-between items-center">
-      <h1 class="px-4 py-3">
+      <strong class="px-4 py-3">
         <span class="font-medium text-2xl">{title}</span>
-      </h1>
+      </strong>
       {onClose && (
         <Button class="btn btn-ghost" onClick={onClose}>
           <Icon id="XMark" size={24} strokeWidth={2} />

--- a/components/product/ProductCard.tsx
+++ b/components/product/ProductCard.tsx
@@ -287,8 +287,7 @@ function ProductCard({
                           class="truncate text-base lg:text-lg text-base-content uppercase font-normal"
                           dangerouslySetInnerHTML={{ __html: name ?? "" }}
                         />
-                      )
-                    }
+                      )}
                   </div>
                 )}
               {l?.hide?.productDescription

--- a/components/product/ProductCard.tsx
+++ b/components/product/ProductCard.tsx
@@ -54,6 +54,7 @@ interface Props {
 
   layout?: Layout;
   platform?: Platform;
+  shelf?: boolean;
 }
 
 const WIDTH = 200;
@@ -66,6 +67,7 @@ function ProductCard({
   layout,
   platform,
   index,
+  shelf,
 }: Props) {
   const { url, productID, name, image: images, offers, isVariantOf } = product;
   const id = `product-card-${productID}`;
@@ -272,10 +274,22 @@ function ProductCard({
                   ""
                 )
                 : (
-                  <h2
-                    class="truncate text-base lg:text-lg text-base-content uppercase font-normal"
-                    dangerouslySetInnerHTML={{ __html: name ?? "" }}
-                  />
+                  <div>
+                    {shelf
+                      ? (
+                        <h3
+                          class="truncate text-base lg:text-lg text-base-content uppercase font-normal"
+                          dangerouslySetInnerHTML={{ __html: name ?? "" }}
+                        />
+                      )
+                      : (
+                        <h2
+                          class="truncate text-base lg:text-lg text-base-content uppercase font-normal"
+                          dangerouslySetInnerHTML={{ __html: name ?? "" }}
+                        />
+                      )
+                    }
+                  </div>
                 )}
               {l?.hide?.productDescription
                 ? (

--- a/components/product/ProductShelf.tsx
+++ b/components/product/ProductShelf.tsx
@@ -59,7 +59,7 @@ function ProductShelf({
   return (
     <div class="w-full container py-8 flex flex-col gap-6 lg:py-10">
       <Header
-        title={title || ""}
+        title={title || "Promotional Items"}
         description={description || ""}
         fontSize={layout?.headerfontSize || "Large"}
         alignment={layout?.headerAlignment || "center"}
@@ -85,6 +85,7 @@ function ProductShelf({
                 layout={cardLayout}
                 platform={platform}
                 index={index}
+                shelf={true}
               />
             </Slider.Item>
           ))}

--- a/components/search/Controls.tsx
+++ b/components/search/Controls.tsx
@@ -27,9 +27,9 @@ function SearchControls(
         <>
           <div class="bg-base-100 flex flex-col h-full divide-y overflow-y-hidden">
             <div class="flex justify-between items-center">
-              <h1 class="px-4 py-3">
+              <strong class="px-4 py-3">
                 <span class="font-medium text-2xl">Filtrar</span>
-              </h1>
+              </strong>
               <Button class="btn btn-ghost" onClick={() => open.value = false}>
                 <Icon id="XMark" size={24} strokeWidth={2} />
               </Button>

--- a/components/ui/SectionHeader.tsx
+++ b/components/ui/SectionHeader.tsx
@@ -24,7 +24,7 @@ function Header(props: Props) {
           >
             {props.title &&
               (
-                <h1
+                <h2
                   class={`text-2xl font-light leading-8 lg:leading-10
                   ${
                     props.colorReverse
@@ -35,7 +35,7 @@ function Header(props: Props) {
                 `}
                 >
                   {props.title}
-                </h1>
+                </h2>
               )}
             {props.description &&
               (


### PR DESCRIPTION
Replacing certain tags with more semantic ones and implementing logic for ProductCard, such as using the <h3> tag when it's in ProductShelf, while continuing to use the <h2> tag for catalog pages, for example.